### PR TITLE
Exclude notebooks from GitHub language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-generated


### PR DESCRIPTION
I added configuration for [linguist](https://github.com/github/linguist) (used by github) in order to remove notebooks from the stats.

Before:
```
99.23%  Jupyter Notebook
0.77%   Python

Jupyter Notebook:
reporting.ipynb

Python:
setup.py
sklearn_benchmarks/__main__.py
sklearn_benchmarks/benchmark.py
sklearn_benchmarks/config.py
sklearn_benchmarks/report.py
sklearn_benchmarks/utils/misc.py
sklearn_benchmarks/utils/plotting.py
```

After:
```
100.00% Python

Python:
setup.py
sklearn_benchmarks/__main__.py
sklearn_benchmarks/benchmark.py
sklearn_benchmarks/config.py
sklearn_benchmarks/report.py
sklearn_benchmarks/utils/misc.py
sklearn_benchmarks/utils/plotting.py
```